### PR TITLE
feat(account): update address property names in API documentation

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -44,8 +44,8 @@ class AccountController extends Controller
      *                    @OA\Property(property="id", type="string", example="550e8400-e29b-41d4-a716-446655440000"),
      *                    @OA\Property(property="name", type="string", example="Nguyễn Văn A"),
      *                    @OA\Property(property="phone", type="string", example="0901234567"),
-     *                    @OA\Property(property="address_line_1", type="string", example="123 Đường Nguyễn Huệ"),
-     *                    @OA\Property(property="address_line_2", type="string", example="Phường Bến Nghé"),
+     *                    @OA\Property(property="address_line1", type="string", example="123 Đường Nguyễn Huệ"),
+     *                    @OA\Property(property="address_line2", type="string", example="Phường Bến Nghé"),
      *                    @OA\Property(property="city", type="string", example="Quận 1"),
      *                    @OA\Property(property="state", type="string", example="TP Hồ Chí Minh"),
      *                    @OA\Property(property="country", type="string", example="Việt Nam"),
@@ -78,11 +78,11 @@ class AccountController extends Controller
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"name", "phone", "address_line_1", "city", "country", "postal_code"},
+     *             required={"name", "phone", "address_line1", "city", "country", "postal_code"},
      *             @OA\Property(property="name", type="string", example="Nguyễn Văn A", description="Tên người nhận"),
      *             @OA\Property(property="phone", type="string", example="0901234567", description="Số điện thoại"),
-     *             @OA\Property(property="address_line_1", type="string", example="123 Đường Nguyễn Huệ", description="Địa chỉ dòng 1"),
-     *             @OA\Property(property="address_line_2", type="string", example="Phường Bến Nghé", description="Địa chỉ dòng 2"),
+     *             @OA\Property(property="address_line1", type="string", example="123 Đường Nguyễn Huệ", description="Địa chỉ dòng 1"),
+     *             @OA\Property(property="address_line2", type="string", example="Phường Bến Nghé", description="Địa chỉ dòng 2"),
      *             @OA\Property(property="city", type="string", example="Quận 1", description="Quận/Huyện"),
      *             @OA\Property(property="state", type="string", example="TP Hồ Chí Minh", description="Tỉnh/Thành phố"),
      *             @OA\Property(property="country", type="string", example="Việt Nam", description="Quốc gia"),
@@ -98,8 +98,8 @@ class AccountController extends Controller
      *                 @OA\Property(property="id", type="string", example="550e8400-e29b-41d4-a716-446655440000"),
      *                 @OA\Property(property="name", type="string", example="Nguyễn Văn A"),
      *                 @OA\Property(property="phone", type="string", example="0901234567"),
-     *                 @OA\Property(property="address_line_1", type="string", example="123 Đường Nguyễn Huệ"),
-     *                 @OA\Property(property="address_line_2", type="string", example="Phường Bến Nghé"),
+     *                 @OA\Property(property="address_line1", type="string", example="123 Đường Nguyễn Huệ"),
+     *                 @OA\Property(property="address_line2", type="string", example="Phường Bến Nghé"),
      *                 @OA\Property(property="city", type="string", example="Quận 1"),
      *                 @OA\Property(property="state", type="string", example="TP Hồ Chí Minh"),
      *                 @OA\Property(property="country", type="string", example="Việt Nam"),
@@ -141,8 +141,8 @@ class AccountController extends Controller
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'phone' => 'required|string|max:15',
-            'address_line_1' => 'required|string|max:255',
-            'address_line_2' => 'nullable|string|max:255',
+            'address_line1' => 'required|string|max:255',
+            'address_line2' => 'nullable|string|max:255',
             'city' => 'required|string|max:100',
             'state' => 'nullable|string|max:100',
             'country' => 'required|string|max:100',
@@ -156,8 +156,8 @@ class AccountController extends Controller
             'id' => Str::uuid()->toString(),
             'name' => $request->name,
             'phone' => $request->phone,
-            'address_line_1' => $request->address_line_1,
-            'address_line_2' => $request->address_line_2 ?? '',
+            'address_line1' => $request->address_line1,
+            'address_line2' => $request->address_line2 ?? '',
             'city' => $request->city,
             'state' => $request->state ?? '',
             'country' => $request->country,
@@ -166,10 +166,10 @@ class AccountController extends Controller
         ];
         foreach ($addresses as $address) {
             if (
-                ($address['address_line_1'] ?? $address['address_line1']) === $newAddress['address_line_1'] &&
-                $address['city'] === $newAddress['city'] &&
-                $address['country'] === $newAddress['country'] &&
-                $address['postal_code'] === $newAddress['postal_code']
+                ($address['address_line1'] ?? '') === $newAddress['address_line1'] &&
+                ($address['city'] ?? '') === $newAddress['city'] &&
+                ($address['country'] ?? '') === $newAddress['country'] &&
+                ($address['postal_code'] ?? '') === $newAddress['postal_code']
             ) {
                 return $this->fail([], 'Địa chỉ đã tồn tại', 400);
             }
@@ -210,8 +210,8 @@ class AccountController extends Controller
      *         @OA\JsonContent(
      *             @OA\Property(property="name", type="string", example="Nguyễn Văn A", description="Tên người nhận"),
      *             @OA\Property(property="phone", type="string", example="0901234567", description="Số điện thoại"),
-     *             @OA\Property(property="address_line_1", type="string", example="123 Đường ABC", description="Địa chỉ dòng 1"),
-     *             @OA\Property(property="address_line_2", type="string", example="Tầng 2", description="Địa chỉ dòng 2"),
+     *             @OA\Property(property="address_line1", type="string", example="123 Đường ABC", description="Địa chỉ dòng 1"),
+     *             @OA\Property(property="address_line2", type="string", example="Tầng 2", description="Địa chỉ dòng 2"),
      *             @OA\Property(property="city", type="string", example="Hồ Chí Minh", description="Thành phố"),
      *             @OA\Property(property="state", type="string", example="", description="Tỉnh/Bang"),
      *             @OA\Property(property="country", type="string", example="Việt Nam", description="Quốc gia"),
@@ -227,8 +227,8 @@ class AccountController extends Controller
      *                 @OA\Property(property="id", type="string", example="550e8400-e29b-41d4-a716-446655440000"),
      *                 @OA\Property(property="name", type="string", example="Nguyễn Văn A"),
      *                 @OA\Property(property="phone", type="string", example="0901234567"),
-     *                 @OA\Property(property="address_line_1", type="string", example="123 Đường ABC"),
-     *                 @OA\Property(property="address_line_2", type="string", example="Tầng 2"),
+     *                 @OA\Property(property="address_line1", type="string", example="123 Đường ABC"),
+     *                 @OA\Property(property="address_line2", type="string", example="Tầng 2"),
      *                 @OA\Property(property="city", type="string", example="Hồ Chí Minh"),
      *                 @OA\Property(property="state", type="string", example=""),
      *                 @OA\Property(property="country", type="string", example="Việt Nam"),
@@ -272,8 +272,8 @@ class AccountController extends Controller
         $fieldsToUpdate = [
             'name',
             'phone',
-            'address_line_1',
-            'address_line_2',
+            'address_line1',
+            'address_line2',
             'city',
             'state',
             'country',
@@ -344,6 +344,20 @@ class AccountController extends Controller
         $user->addresses = $addresses;
         $user->save();
         return $this->json([], 'Địa chỉ đã được xóa thành công', 200);
+    }
+
+    #[Post("/addresses/set-default-address/{id}", "account.addresses.setDefaultAddress")]
+    public function setDefaultAddress(Request $request, string $id)
+    {
+        $user = $request->user();
+        $user->addresses = array_map(function ($address) use ($id) {
+            $address['is_default'] = $address['id'] === $id;
+            return $address;
+        }, $user->addresses);
+        $user->save();
+
+        $defaultAddress = collect($user->addresses)->firstWhere('is_default', true);
+        return $this->json($defaultAddress, 'Đặt địa chỉ mặc định thành công', 200);
     }
 
     #[Patch(uri: "/profile/update", name: "account.profile.update")]

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -113,7 +113,7 @@ class OrderController extends Controller
      *                     @OA\Property(property="id", type="string", example="550e8400-e29b-41d4-a716-446655440000"),
      *                     @OA\Property(property="name", type="string", example="Nguyễn Văn A"),
      *                     @OA\Property(property="phone", type="string", example="0901234567"),
-     *                     @OA\Property(property="address_line_1", type="string", example="123 Đường Nguyễn Huệ"),
+     *                     @OA\Property(property="address_line1", type="string", example="123 Đường Nguyễn Huệ"),
      *                     @OA\Property(property="city", type="string", example="Quận 1"),
      *                     @OA\Property(property="state", type="string", example="TP Hồ Chí Minh"),
      *                     @OA\Property(property="country", type="string", example="Việt Nam")

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Models\Medicine;
+use Illuminate\Http\Request;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Patch;
+use Spatie\RouteAttributes\Attributes\Prefix;
+
+#[Prefix('v1/store')]
+class StoreController extends Controller
+{
+    #[Get('/medicines', name: 'store.medicines')]
+    public function Medicines(Request $request)
+    {
+        // Get all medicines with pagination
+        $medicines = Medicine::with('category')
+            ->orderBy('created_at', 'desc')
+            ->paginate(10);
+
+        return $this->json($medicines, "Lấy danh sách thuốc thành công");
+    }
+
+    #[Get('/medicines/{id}/details', name: 'store.medicines.show')]
+    public function MedicineDetails($id)
+    {
+        // Get medicine details by ID
+        $medicine = Medicine::with('category')
+            ->where('id', $id)
+            ->first();
+        if (!$medicine) return $this->json(null, "Không tìm thấy thuốc", 404);
+        return $this->json($medicine, "Lấy thông tin thuốc thành công");
+    }
+
+    #[Get('/categories', name: 'store.categories')]
+    public function RootCategories()
+    {
+        $categories = Category::all();
+        return $this->json($categories, "Lấy toàn bộ danh mục thành công");
+    }
+
+    #[Get('/popular-medicine', name: 'store.popular-medicine')]
+    public function PopularMedicine()
+    {
+        // Get top 4 medicines with highest likes and star ratings
+        $medicines = Medicine::orderBy('ratings.liked', 'desc')
+            ->orderBy('ratings.star', 'desc')
+            ->limit(4)
+            ->get();
+
+        return $this->json($medicines, "Lấy 4 sản phẩm thuốc có lượt thích và đánh giá cao nhất thành công");
+    }
+
+    #[Patch('/account/update-profile', name: 'store.account.update-profile')]
+    public function updateProfile() {}
+}


### PR DESCRIPTION
- Change address_line_1 and address_line_2 to address_line1 and address_line2 for consistency.
- Add setDefaultAddress method to manage default addresses for users.