### PR TITLE
feat(auth, medicine): add token refresh and medicine statistics endpoints

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -659,4 +659,26 @@ class AuthController extends Controller
       'user' => $user,
     ], "Đăng nhập thành công");
   }
+
+  #[Post('/refresh-token', 'auth.refreshToken')]
+  public function refreshToken()
+  {
+    $currentToken = JWTAuth::getToken();
+    if (!$currentToken) return $this->fail(null, 'Không tìm thấy token hiện tại', 401);
+    $newToken = JWTAuth::refresh($currentToken);
+    $ttl = config('jwt.ttl') * 60;
+    $user = JWTAuth::setToken($newToken)->toUser();
+    Log::info('Token refreshed successfully', [
+      'user_id' => $user ? $user->id : 'unknown',
+      'email' => $user ? $user->email : 'unknown',
+      'ip' => request()->ip(),
+      'user_agent' => request()->userAgent()
+    ]);
+    $data = [
+      'access_token' => $newToken,
+      'token_type' => 'Bearer',
+      'expires_in' => $ttl,
+    ];
+    return $this->json($data, 'Làm mới token thành công', 200);
+  }
 }

--- a/app/Http/Controllers/MedicineController.php
+++ b/app/Http/Controllers/MedicineController.php
@@ -146,6 +146,16 @@ class MedicineController extends Controller
         return $this->json($medicines, 'Danh sách thuốc', 200);
     }
 
+    #[Get(uri: "/statistics", name: "admin.medicine.statistic", middleware: "role:admin")]
+    public function getMedicineStatisticAdmin()
+    {
+        $totalMedicine = Medicine::count();
+        $data = [
+            'total_medicine' => $totalMedicine,
+        ];
+        return $this->json($data, 'Thống kê thuốc');
+    }
+
     /**
      * @OA\Get(
      *     path="/v1/admin/medicines/{id}/details",


### PR DESCRIPTION
- Introduced a new POST endpoint for refreshing JWT tokens, including error handling for missing tokens and logging for successful refreshes.
- Added a new GET endpoint for admin users to retrieve total medicine statistics, enhancing the API's functionality for administrative tasks.
- Updated response structures to provide clear and informative feedback for both endpoints.